### PR TITLE
feat: 헤더 구현 및 반응형 믹스인 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,19 +1,18 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="'stylesheet" href="./reset.css" />
-    <title>Rolling in the deep</title>
-    <link rel="icon" href="./favicon.ico" />
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-  </body>
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Web site created using create-react-app" />
+  <title>Rolling in the deep</title>
+  <link rel="icon" href="./favicon.ico" />
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+</body>
+
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,13 @@
+import Header from 'components/Header';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+
 function App() {
-  return <h2>react app</h2>;
+  return (
+    <Router>
+      <Header />
+      <Routes></Routes>
+    </Router>
+  );
 }
 
 export default App;

--- a/src/assets/styles/common.scss
+++ b/src/assets/styles/common.scss
@@ -3,10 +3,36 @@
 // flex box 공통적으로 사용할 수 있게끔
 // 사용하지 않을 속성은 ''으로 작성하면 됨, 파라미터 개수 순서는 맞춰야함
 // ex) @include Flex(column, center, '', '')
-@mixin Flex($col, $justifyContent, $alignItems, $gap) { 
-    display: flex;
-    flex-direction: $col;
-    justify-content: $justifyContent;
-    align-items:$alignItems;
-    gap: $gap;
+@mixin Flex($col, $justifyContent, $alignItems, $gap) {
+  display: flex;
+  flex-direction: $col;
+  justify-content: $justifyContent;
+  align-items: $alignItems;
+  gap: $gap;
+}
+
+// 반응형 레이아웃 설정
+// 믹스인을 호출해서 스타일을 작성하면 @content에 전달됨
+// ex) @include mobile or tablet or desktop { 해당 디바이스에서 적용할 스타일 }
+$mobile-max: 767px;
+$tablet-min: 768px;
+$tablet-max: 1023px;
+$desktop-min: 1024px;
+
+@mixin desktop {
+  @media screen and (min-width: $desktop-min) {
+    @content;
+  }
+}
+
+@mixin tablet {
+  @media screen and (min-width: $tablet-min) and (max-width: $tablet-max) {
+    @content;
+  }
+}
+
+@mixin mobile {
+  @media screen and (max-width: $mobile-max) {
+    @content;
+  }
 }

--- a/src/assets/styles/reset.scss
+++ b/src/assets/styles/reset.scss
@@ -1,10 +1,12 @@
-/* reset.css */
+/* reset.scss */
 
 /* http://meyerweb.com/eric/tools/css/reset/ 
    v2.0 | 20110126
    License: none (public domain)
 */
-
+* {
+  margin: 0;
+}
 html,
 body,
 div,
@@ -12,7 +14,9 @@ span,
 applet,
 object,
 iframe,
-h1,
+h1 {
+  text-decoration: none;
+}
 h2,
 h3,
 h4,
@@ -21,7 +25,9 @@ h6,
 p,
 blockquote,
 pre,
-a,
+a {
+  text-decoration: none;
+}
 abbr,
 acronym,
 address,

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,23 @@
+import logo from 'assets/images/ic_logo.svg';
+import styles from 'components/Header.module.scss';
+import { Link, useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useMediaQuery } from 'react-responsive';
+
+function Header() {
+  return (
+    <header className={styles.header}>
+      <div className={styles.container}>
+        <Link to='/' className={styles.wrapper}>
+          <img src={logo} className={styles.logo} alt='로고' />
+          <h1 className={styles.logo}>Rolling</h1>
+        </Link>
+        <Link to='/post' className={styles.button}>
+          롤링 페이퍼 만들기
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+export default Header;

--- a/src/components/Header.module.scss
+++ b/src/components/Header.module.scss
@@ -1,0 +1,54 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
+@import 'assets/styles/palette.scss';
+@import 'assets/styles/fonts.scss';
+@import 'assets/styles/common.scss';
+
+.visible {
+  display: flex;
+}
+
+.invisible {
+  display: none;
+}
+
+.header {
+  border-bottom: 1px solid #ededed;
+
+  .container {
+    @include Flex(row, space-between, center, 0);
+
+    @include desktop {
+      padding: 0 360px;
+    }
+
+    @include tablet {
+      padding: 0 24px;
+    }
+
+    @include mobile {
+      padding: 0 16px;
+    }
+    height: 64px;
+  }
+
+  .wrapper {
+    @include Flex(row, center, center, 8px);
+
+    .logo {
+      @include font-style(20, bold);
+      font-family: 'Poppins', sans-serif;
+      font-style: normal;
+      color: #4a494f;
+    }
+  }
+
+  .button {
+    @include Flex(row, center, center, 0);
+    @include font-style(16, bold);
+    width: 157px;
+    height: 40px;
+    border-radius: 6px;
+    border: 1px solid $gray-300;
+    color: $gray-900;
+  }
+}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,8 +1,10 @@
-import React from "react";
-import ReactDOM from "react-dom/client";
-import App from "./App";
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from 'App';
+import 'assets/styles/fonts.scss';
+import 'assets/styles/reset.scss';
 
-const root = ReactDOM.createRoot(document.getElementById("root"));
+const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
- 헤더 컴포넌트 구현 및 반응형 디자인 적용
- 반응형 믹스인 추가
- index.html head에 stylesheet 삭제
- index.jsx에 global style 추가
- App.jsx에 Header 컴포넌트 추가 및 Router 적용
- reset.css -> reset.scss로 변경, public에서 src 폴더로 이동
- 모든 태그에 margin: 0 적용
- h1, a 태그에 text-decoration:none 적용